### PR TITLE
Test to re-enable linting with flake8

### DIFF
--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -21,10 +21,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e .
-    # - name: Lint with flake8
-    #   run: |
-    #     # stop the build if there are Python syntax errors or undefined names
-    #     ./Tools/lib/check-style
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        ./Tools/lib/check-style
     - name: Refresh secrets
       run: |
         ./Tools/lib/gen-env

--- a/flaskr/db.py
+++ b/flaskr/db.py
@@ -7,7 +7,7 @@ from flask_marshmallow import Marshmallow
 from flask_sqlalchemy import SQLAlchemy, event
 from sqlalchemy import MetaData
 from sqlalchemy.orm.session import Session
-from sqlalchemy.sql.expression import delete, update
+from sqlalchemy.sql.expression import update
 
 metadata = MetaData(naming_convention={
     "ix": 'ix,%(column_0_label)s',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E501, WPS453, PT007, E800
+ignore = E501, E731, E800, N803, N815, PT007, WPS453
 select = C, E, F, W, B, N, A, C4, PT, C8
 exclude = 
     venv/,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
         'cerberus',
         'coverage',
         'flake8',
-        'flake8-bandit',
         'flake8-bugbear',
         'flake8-builtins',
         'flake8-commas',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ default_course = {
     'CourseTitle': 'Sample Course',
     'CourseNumber': 1234567890,
     'CourseStart': datetime.now().timestamp(),
-    'CourseEnd': (datetime.now() + timedelta(days=30)).timestamp()
+    'CourseEnd': (datetime.now() + timedelta(days=30)).timestamp(),
 }
 
 default_user = {

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import pytest
-from flaskr.db import User
 from tests.conftest import parse_data
 
 

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -3,12 +3,12 @@
 import pytest
 from datetime import datetime, timedelta
 from flaskr.db import Course
-from tests.conftest import default_auth, default_user, parse_data
+from tests.conftest import parse_data
 
 
 @pytest.mark.parametrize(('CourseTitle', 'CourseNumber', 'CourseStart', 'CourseEnd', 'status', 'error'), (
     ('', '', 0, 0, 400, {'CourseTitle': ['empty values not allowed'], 'CourseNumber': ['empty values not allowed']}),
-    ('Sample Title', 1234, datetime.now().timestamp() ,(datetime.now() + timedelta(days=30)).timestamp(), 200, {}),
+    ('Sample Title', 1234, datetime.now().timestamp(), (datetime.now() + timedelta(days=30)).timestamp(), 200, {}),
 ))
 def test_validate_create_course_input(course, CourseTitle, CourseNumber, CourseStart, CourseEnd, status, error):
     response = course.create(data={'CourseTitle': CourseTitle, 'CourseNumber': CourseNumber, 'CourseStart': CourseStart, 'CourseEnd': CourseEnd})

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
 import pytest
-from datetime import datetime
-from flaskr.db import  User
-from tests.conftest import default_auth, default_user, parse_data
+from flaskr.db import User
+from tests.conftest import parse_data
 
 
 @pytest.mark.parametrize(('Email', 'Password', 'FirstName', 'LastName', 'SaltKey', 'status', 'error'), (


### PR DESCRIPTION
Error when running `flaskr check-style`:

```
(venv) chris@Chriss-MacBook-Pro cabem % flaskr check-style
Checking style...
Traceback (most recent call last):
  File "/Users/chris/dev/cabem/venv/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/Users/chris/dev/cabem/venv/lib/python3.8/site-packages/flake8/main/cli.py", line 22, in main
    app.run(argv)
  File "/Users/chris/dev/cabem/venv/lib/python3.8/site-packages/flake8/main/application.py", line 375, in run
    self._run(argv)
  File "/Users/chris/dev/cabem/venv/lib/python3.8/site-packages/flake8/main/application.py", line 364, in _run
    self.run_checks()
  File "/Users/chris/dev/cabem/venv/lib/python3.8/site-packages/flake8/main/application.py", line 271, in run_checks
    self.file_checker_manager.run()
  File "/Users/chris/dev/cabem/venv/lib/python3.8/site-packages/flake8/checker.py", line 311, in run
    self.run_serial()
  File "/Users/chris/dev/cabem/venv/lib/python3.8/site-packages/flake8/checker.py", line 295, in run_serial
    checker.run_checks()
  File "/Users/chris/dev/cabem/venv/lib/python3.8/site-packages/flake8/checker.py", line 597, in run_checks
    self.run_ast_checks()
  File "/Users/chris/dev/cabem/venv/lib/python3.8/site-packages/flake8/checker.py", line 500, in run_ast_checks
    for (line_number, offset, text, _) in runner:
  File "/Users/chris/dev/cabem/venv/lib/python3.8/site-packages/flake8_bandit.py", line 85, in run
    for warn in self._check_source():
  File "/Users/chris/dev/cabem/venv/lib/python3.8/site-packages/flake8_bandit.py", line 59, in _check_source
    bnv = BanditNodeVisitor(
TypeError: __init__() missing 1 required positional argument: 'metrics'
```